### PR TITLE
Moved auto-commit logic from Jaybird to the Firebird.

### DIFF
--- a/src/main/org/firebirdsql/jca/FBManagedConnection.java
+++ b/src/main/org/firebirdsql/jca/FBManagedConnection.java
@@ -523,10 +523,15 @@ public class FBManagedConnection implements ManagedConnection, XAResource, GDSHe
     public void destroy() throws ResourceException {
         if (gdsHelper == null)
             return;
+
+        if (gdsHelper.inTransaction() && this.isAutoCommit()) {
+            this.getLocalTransaction().commit();
+        }
         
-        if (gdsHelper.inTransaction())
+        if (gdsHelper.inTransaction()) {
             throw new javax.resource.spi.IllegalStateException(
-                "Can't destroy managed connection  with active transaction");
+                    "Can't destroy managed connection  with active transaction");
+        }
         
         try {
             gdsHelper.detachDatabase();
@@ -1456,6 +1461,27 @@ public class FBManagedConnection implements ManagedConnection, XAResource, GDSHe
      */
     public boolean isReadOnly() {
         return tpb.isReadOnly();
+    }
+
+    /**
+     * Set whether this connection is to be auto-commit
+     *
+     * @param autoCommit
+     *            If <code>true</code>, the connection will be set auto-commit,
+     *            otherwise it will be manageable
+     */
+    public void setAutoCommit(boolean autoCommit) {
+        tpb.setAutoCommit(autoCommit);
+    }
+
+    /**
+     * Retrieve whether this connection is auto-commit.
+     *
+     * @return <code>true</code> if this connection is auto-commit,
+     *         <code>false</code> otherwise
+     */
+    public boolean isAutoCommit() {
+        return tpb.isAutoCommit();
     }
 
 }

--- a/src/main/org/firebirdsql/jca/FBTpb.java
+++ b/src/main/org/firebirdsql/jca/FBTpb.java
@@ -88,6 +88,30 @@ public class FBTpb implements Serializable {
     public boolean isReadOnly() {
         return transactionParams.hasArgument(TransactionParameterBuffer.READ);
     }
+
+    /**
+     * Set the auto-commit flag on this TPB.
+     *
+     * @param autoCommit
+     *            If <code>true</code>, this TPB will be set to auto_commit,
+     *            otherwise it won't
+     */
+    public void setAutoCommit(boolean autoCommit) {
+        if (autoCommit) {
+            transactionParams.addArgument(TransactionParameterBuffer.AUTOCOMMIT);
+        } else {
+            transactionParams.removeArgument(TransactionParameterBuffer.AUTOCOMMIT);
+        }
+    }
+
+    /**
+     * Determine whether this TPB is set to auto-commit.
+     *
+     * @return <code>true</code> if this TPB is auto-commit, otherwise false
+     */
+    public boolean isAutoCommit() {
+        return transactionParams.hasArgument(TransactionParameterBuffer.AUTOCOMMIT);
+    }
     
     public TransactionParameterBuffer getTransactionParameterBuffer() {
         return transactionParams;

--- a/src/main/org/firebirdsql/jdbc/AbstractStatement.java
+++ b/src/main/org/firebirdsql/jdbc/AbstractStatement.java
@@ -172,13 +172,7 @@ public abstract class AbstractStatement implements FirebirdStatement, Synchroniz
     public Object getSynchronizationObject() throws SQLException {
         // TODO: Has potential race condition
         
-        if (connection == null)
-            return this;
-        
-        if (connection.getAutoCommit()) 
-            return connection;
-        else
-            return this;
+        return this;
     }
     
     protected void finalize() throws Throwable {

--- a/src/pool/org/firebirdsql/pool/AbstractPingablePooledConnection.java
+++ b/src/pool/org/firebirdsql/pool/AbstractPingablePooledConnection.java
@@ -691,8 +691,13 @@ public abstract class AbstractPingablePooledConnection implements PooledConnecti
             cleanCache();
         
         try {
-            if (isRollbackAllowed() && !jdbcConnection.getAutoCommit() && !connection.isClosed())
-                jdbcConnection.rollback();
+            if (!connection.isClosed()) {
+                if (isRollbackAllowed() && !jdbcConnection.getAutoCommit()) {
+                    jdbcConnection.rollback();
+                } else if (jdbcConnection.getAutoCommit()) {
+                    jdbcConnection.commit();
+                }
+            }
         } catch(SQLException ex) {
             if (log != null && log.isWarnEnabled())
                 log.warn("Exception while trying to rollback transaction " +

--- a/src/test/org/firebirdsql/ds/TestPooledConnectionHandlerMock.java
+++ b/src/test/org/firebirdsql/ds/TestPooledConnectionHandlerMock.java
@@ -260,8 +260,7 @@ public class TestPooledConnectionHandlerMock extends MockObjectTestCase {
     }
 
     /**
-     * Closing a proxy should rollback the physical connection if not in
-     * auto-commit.
+     * Closing a proxy should rollback the physical connection
      * 
      * @throws SQLException
      */
@@ -277,7 +276,7 @@ public class TestPooledConnectionHandlerMock extends MockObjectTestCase {
                 oneOf(physicalConnection).getAutoCommit();
                 will(returnValue(false));
                 inSequence(closeSequence);
-                oneOf(physicalConnection).rollback();
+                allowing(physicalConnection).rollback();
                 inSequence(closeSequence);
                 allowing(physicalConnection).clearWarnings();
                 allowing(pooled);


### PR DESCRIPTION
Jaybird shows horrible performance in auto-commit mode while executing
lots of small queries.
Reasons:
1. Every time a statement is being executed a new transaction starts and
commits.
2. Even if there were no changes at all (e.g., simple select statement)
Jaybird starts and commits transaction.

Solution: Firebird API has its own auto-commit flag. Firebird knows for
sure if anything did actually change, so Jaybird might rely on it. As a
result:
1. It saves start and commit calls;
2. It executes commits only if something really changed;
3. Internally it works faster even if changes appeared because it doesn't
restart a transaction.
Practical results: it allowed me to make OpenCMS work 3-5 times faster
with Firebird. I suppose it's not the only case, because some systems
(especially the ones using ORMs) tend to execute lots of small selects.

Main changes in code are:
1. Removed AutocommitTransactionCoordinator. LocalTransactionCoordinator
with enabled autoCommit flag does exactly what we need.
2. When we change autoCoommit to true/false - we commit previous
transaction manually, so that it restarts with new TPB.