### PR TITLE
fix invalid char

### DIFF
--- a/examples/DataSourceExample.java
+++ b/examples/DataSourceExample.java
@@ -8,7 +8,7 @@
 //
 // An example of using a JDBC 2 Standard Extension DataSource.
 // The DataSource facility provides an alternative to the JDBC DriverManager,
-// essentially duplicating all of the driver manager’s useful functionality.
+// essentially duplicating all of the driver manager's useful functionality.
 // Although, both mechanisms may be used by the same application if desired,
 // JavaSoft encourages developers to regard the DriverManager as a legacy
 // feature of the JDBC API.

--- a/src/main/org/firebirdsql/jdbc/escape/FBEscapedFunctionHelper.java
+++ b/src/main/org/firebirdsql/jdbc/escape/FBEscapedFunctionHelper.java
@@ -327,7 +327,7 @@ public class FBEscapedFunctionHelper {
         if (!FUNCTION_MAP.containsKey(functionName)) {
             /* See 13.4.1 of JDBC 4.1 spec:
              * "The escape syntax for scalar functions must only be used to invoke the scalar
-             * functions defined in Appendix D “Scalar Functions". The escape syntax is not
+             * functions defined in Appendix D "Scalar Functions". The escape syntax is not
              * intended to be used to invoke user-defined or vendor specific scalar functions."
              */
             // TODO Consider throwing SQLFeatureNotSupported or a different SQLException


### PR DESCRIPTION
    [javac] Compiling 358 source files to /tmp/jaybird/output/classes
    [javac] /tmp/jaybird/src/main/org/firebirdsql/jdbc/escape/FBEscapedFunctionHelper.java:330: error: unmappable character for encoding UTF8
    [javac]              * functions defined in Appendix D �Scalar Functions". The escape syntax is not
    [javac]                                                ^
    [javac] 1 error