### PR TITLE
Adds support for the streaming Backup/Restore operations in FirebirdSQL

### DIFF
--- a/src/main/org/firebirdsql/gds/impl/argument/ByteArrayArgument.java
+++ b/src/main/org/firebirdsql/gds/impl/argument/ByteArrayArgument.java
@@ -18,6 +18,7 @@
  */
 package org.firebirdsql.gds.impl.argument;
 
+import org.firebirdsql.gds.ISCConstants;
 import org.firebirdsql.encodings.Encoding;
 import org.firebirdsql.gds.ParameterBuffer;
 
@@ -40,21 +41,25 @@ public final class ByteArrayArgument extends Argument {
      * Initializes an instance of ByteArrayArgument.
      *
      * @param type
-     *         Parameter type
+     *        Parameter type
      * @param value
-     *         Byte array with a length up to 255 bytes.
+     *        Byte array with a length up to 255 bytes.
      */
     public ByteArrayArgument(int type, ArgumentType argumentType, byte[] value) {
         super(type);
         this.argumentType = argumentType;
-        if (argumentType != ArgumentType.TraditionalDpb && argumentType != ArgumentType.Wide) {
-            throw new IllegalArgumentException("ByteArrayArgument only works for TraditionalDpb or Wide, was: " + argumentType);
+        if (argumentType != ArgumentType.TraditionalDpb && argumentType != ArgumentType.Wide
+                && argumentType != ArgumentType.StringSpb) {
+            throw new IllegalArgumentException(
+                    "ByteArrayArgument only works for TraditionalDpb, Wide, or StringSpb was: " + argumentType);
         }
         if (value == null) {
             throw new IllegalArgumentException("byte array value should not be null");
         }
         if (value.length > argumentType.getMaxLength()) {
-            throw new IllegalArgumentException(String.format("byte array value should not be longer than %d bytes, length was %d", argumentType.getMaxLength(), value.length));
+            throw new IllegalArgumentException(
+                    String.format("byte array value should not be longer than %d bytes, length was %d",
+                            argumentType.getMaxLength(), value.length));
         }
         this.value = value;
     }
@@ -68,7 +73,7 @@ public final class ByteArrayArgument extends Argument {
 
     @Override
     public int getLength() {
-        return 1 + argumentType.getLengthSize() + value.length ;
+        return 1 + argumentType.getLengthSize() + value.length;
     }
 
     @Override
@@ -93,7 +98,8 @@ public final class ByteArrayArgument extends Argument {
 
         final ByteArrayArgument otherByteArrayArgument = (ByteArrayArgument) other;
 
-        return this.getType() == otherByteArrayArgument.getType() && Arrays.equals(this.value, otherByteArrayArgument.value);
+        return this.getType() == otherByteArrayArgument.getType()
+                && Arrays.equals(this.value, otherByteArrayArgument.value);
     }
 
     @Override

--- a/src/main/org/firebirdsql/management/FBBackupManagerBase.java
+++ b/src/main/org/firebirdsql/management/FBBackupManagerBase.java
@@ -1,0 +1,312 @@
+/*
+ * Firebird Open Source JavaEE Connector - JDBC Driver
+ *
+ * Distributable under LGPL license.
+ * You may obtain a copy of the License at http://www.gnu.org/copyleft/lgpl.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * LGPL License for more details.
+ *
+ * This file was created by members of the firebird development team.
+ * All individual contributions remain the Copyright (C) of those
+ * individuals.  Contributors to this file are either listed here or
+ * can be obtained from a source control history command.
+ *
+ * All rights reserved.
+ */
+package org.firebirdsql.management;
+
+import org.firebirdsql.gds.ServiceRequestBuffer;
+import org.firebirdsql.gds.impl.GDSType;
+import org.firebirdsql.gds.ng.FbService;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.firebirdsql.gds.ISCConstants.*;
+
+/**
+ * Implements the common functionality between regular and streaming backup/restore
+ *
+ * @author <a href="mailto:rrokytskyy@users.sourceforge.net">Roman Rokytskyy</a>
+ * @author <a href="mailto:mrotteveel@users.sourceforge.net">Mark Rotteveel</a>
+ */
+public abstract class FBBackupManagerBase extends FBServiceManager implements BackupManager {
+
+    /**
+     * Structure that holds path to the database and corresponding size of the file (in case of backup - that is
+     * size of the file in megabytes, in case of restore - size of the database file in pages).
+     */
+    protected static class PathSizeStruct {
+        private int size;
+        private String path;
+
+        protected PathSizeStruct(String path, int size) {
+            this.path = path;
+            this.size = size;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (!(obj instanceof PathSizeStruct)) return false;
+
+            PathSizeStruct that = (PathSizeStruct) obj;
+
+            return this.path.equals(that.path);
+        }
+
+        public int hashCode() {
+            return path.hashCode();
+        }
+
+        public String toString() {
+            return path + " " + size;
+        }
+    }
+
+    protected boolean noLimitRestore = false;
+    protected List<PathSizeStruct> restorePaths = new ArrayList<>();
+
+    protected boolean verbose = false;
+
+    private int restoreBufferCount = -1;
+    private int restorePageSize = -1;
+    private boolean restoreReadOnly = false;
+    private boolean restoreReplace = false;
+
+    private static final int RESTORE_REPLACE = isc_spb_res_replace;
+    private static final int RESTORE_CREATE = isc_spb_res_create;
+
+    /**
+     * Create a new instance of <code>FBBackupManagerBase</code> based on the default GDSType.
+     */
+    public FBBackupManagerBase() {
+    }
+
+    /**
+     * Create a new instance of <code>FBBackupManagerBase</code> based on a given GDSType.
+     *
+     * @param gdsType
+     *        type must be PURE_JAVA, EMBEDDED, or NATIVE
+     */
+    public FBBackupManagerBase(String gdsType) {
+        super(gdsType);
+    }
+
+    /**
+     * Create a new instance of <code>FBBackupManagerBase</code> based on a given GDSType.
+     *
+     * @param gdsType
+     *        type must be PURE_JAVA, EMBEDDED, or NATIVE
+     */
+    public FBBackupManagerBase(GDSType gdsType) {
+        super(gdsType);
+    }
+
+    public void addBackupPath(String path) {
+        addBackupPath(path, -1);
+    }
+
+    public void setDatabase(String database) {
+        super.setDatabase(database);
+        addRestorePath(database, -1);
+        noLimitRestore = true;
+    }
+
+    public void addRestorePath(String path, int size) {
+        if (noLimitRestore) {
+            throw new IllegalArgumentException(
+                    "You cannot use setDatabase(String) and addRestorePath(String, int) methods simultaneously.");
+        }
+        restorePaths.add(new PathSizeStruct(path, size));
+    }
+
+    public void clearRestorePaths() {
+        restorePaths.clear();
+        noLimitRestore = false;
+    }
+
+    public void backupDatabase() throws SQLException {
+        backupDatabase(0);
+    }
+
+    public void backupMetadata() throws SQLException {
+        backupDatabase(BACKUP_METADATA_ONLY);
+    }
+
+    /**
+     * Creates and returns the "backup" service request buffer for the Service Manager.
+     *
+     * @param service
+     *        Service handle
+     * @param options
+     *        The isc_spb_bkp_* parameters options to be used
+     * @return the "backup" service request buffer for the Service Manager.
+     */
+    protected ServiceRequestBuffer getBackupSRB(FbService service, int options) throws SQLException {
+        ServiceRequestBuffer backupSPB = service.createServiceRequestBuffer();
+        backupSPB.addArgument(isc_action_svc_backup);
+        backupSPB.addArgument(isc_spb_dbname, getDatabase(), service.getEncoding());
+        addBackupsToBackupRequestBuffer(service, backupSPB);
+
+        if (verboseBackup()) {
+            backupSPB.addArgument(isc_spb_verbose);
+        }
+
+        backupSPB.addArgument(isc_spb_options, options);
+
+        return backupSPB;
+    }
+
+    public void restoreDatabase() throws SQLException {
+        restoreDatabase(0);
+    }
+
+    /**
+     * Set whether the operations of this {@code BackupManager} will result in verbose logging to the configured logger.
+     *
+     * @param verbose
+     *        If <code>true</code>, operations will be logged verbosely, otherwise they will not be logged verbosely
+     */
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    /**
+     * Set the default number of pages to be buffered (cached) by default in a restored database.
+     *
+     * @param bufferCount
+     *        The page-buffer size to be used, a positive value
+     */
+    public void setRestorePageBufferCount(int bufferCount) {
+        if (bufferCount < 0) {
+            throw new IllegalArgumentException("Buffer count must be positive");
+        }
+        this.restoreBufferCount = bufferCount;
+    }
+
+    /**
+     * Set the page size that will be used for a restored database. The value for <code>pageSize</code> must be
+     * one of: 1024, 2048, 4096, 8192 or 16384. The default value depends on the Firebird version.
+     *
+     * @param pageSize
+     *        The page size to be used in a restored database, one of 1024, 2048, 4196, 8192 or 16384
+     */
+    public void setRestorePageSize(int pageSize) {
+        if (pageSize != 1024 && pageSize != 2048
+                && pageSize != 4096 && pageSize != 8192 && pageSize != 16384) {
+            throw new IllegalArgumentException(
+                    "Page size must be one of 1024, 2048, 4096, 8192 or 16384");
+        }
+        this.restorePageSize = pageSize;
+    }
+
+    /**
+     * Set the restore operation to create a new database, as opposed to overwriting an existing database. This is true
+     * by default.
+     *
+     * @param replace
+     *        If <code>true</code>, the restore operation will attempt to create a new database, otherwise
+     *        the restore operation will overwrite an existing database
+     */
+    public void setRestoreReplace(boolean replace) {
+        this.restoreReplace = replace;
+    }
+
+    /**
+     * Set the read-only attribute on a restored database.
+     *
+     * @param readOnly
+     *        If <code>true</code>, a restored database will be read-only, otherwise it will be read-write.
+     */
+    public void setRestoreReadOnly(boolean readOnly) {
+        this.restoreReadOnly = readOnly;
+    }
+
+    /**
+     * Creates and returns the "backup" service request buffer for the Service Manager.
+     *
+     * @param service
+     *        Service handle
+     * @param options
+     *        The options to be used for the backup operation
+     * @return the "backup" service request buffer for the Service Manager.
+     */
+    protected ServiceRequestBuffer getRestoreSRB(FbService service, int options) {
+        ServiceRequestBuffer restoreSPB = service.createServiceRequestBuffer();
+        restoreSPB.addArgument(isc_action_svc_restore);
+
+        // restore files with sizes except the last one
+        for (Iterator<PathSizeStruct> iter = restorePaths.iterator(); iter.hasNext();) {
+            PathSizeStruct pathSize = iter.next();
+
+            restoreSPB.addArgument(isc_spb_dbname, pathSize.getPath(), service.getEncoding());
+
+            if (iter.hasNext() && pathSize.getSize() != -1) {
+                restoreSPB.addArgument(isc_spb_res_length, pathSize.getSize());
+            }
+        }
+
+        addBackupsToRestoreRequestBuffer(service, restoreSPB);
+
+        if (restoreBufferCount != -1) {
+            restoreSPB.addArgument(isc_spb_res_buffers, restoreBufferCount);
+        }
+
+        if (restorePageSize != -1) {
+            restoreSPB.addArgument(isc_spb_res_page_size, restorePageSize);
+        }
+
+        restoreSPB.addArgument(isc_spb_res_access_mode,
+                (byte) (restoreReadOnly
+                        ? isc_spb_res_am_readonly
+                                : isc_spb_res_am_readwrite));
+
+        if (verbose) {
+            restoreSPB.addArgument(isc_spb_verbose);
+        }
+
+        if ((options & RESTORE_CREATE) != RESTORE_CREATE
+                && (options & RESTORE_REPLACE) != RESTORE_REPLACE) {
+            options |= restoreReplace
+                    ? RESTORE_REPLACE
+                            : RESTORE_CREATE;
+        }
+
+        restoreSPB.addArgument(isc_spb_options, options);
+
+        return restoreSPB;
+    }
+
+    /**
+     * Adds the backup source for the backup opration, depending on the manager used
+     *
+     * @param backupSPB
+     *        The buffer to be used during the backup operation
+     */
+    protected abstract void addBackupsToBackupRequestBuffer(FbService service, ServiceRequestBuffer backupSPB)
+            throws SQLException;
+
+    /**
+     * Adds the backup files to be used during restore
+     */
+    protected abstract void addBackupsToRestoreRequestBuffer(FbService service, ServiceRequestBuffer restoreSPB);
+
+    /**
+     * Whether the backup will produce verbose output
+     */
+    protected abstract boolean verboseBackup();
+
+}

--- a/src/main/org/firebirdsql/management/FBStreamingBackupManager.java
+++ b/src/main/org/firebirdsql/management/FBStreamingBackupManager.java
@@ -1,0 +1,324 @@
+/*
+ * Firebird Open Source JavaEE Connector - JDBC Driver
+ *
+ * Distributable under LGPL license.
+ * You may obtain a copy of the License at http://www.gnu.org/copyleft/lgpl.html
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * LGPL License for more details.
+ *
+ * This file was created by members of the firebird development team.
+ * All individual contributions remain the Copyright (C) of those
+ * individuals.  Contributors to this file are either listed here or
+ * can be obtained from a source control history command.
+ *
+ * All rights reserved.
+ */
+package org.firebirdsql.management;
+
+import org.firebirdsql.gds.ServiceRequestBuffer;
+import org.firebirdsql.gds.ServiceParameterBuffer;
+import org.firebirdsql.gds.impl.GDSType;
+import org.firebirdsql.gds.ng.FbService;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Arrays;
+import java.io.OutputStream;
+import java.io.InputStream;
+import java.io.BufferedInputStream;
+
+import static org.firebirdsql.gds.ISCConstants.*;
+import static org.firebirdsql.gds.VaxEncoding.iscVaxInteger2;
+import static org.firebirdsql.gds.VaxEncoding.iscVaxInteger;
+
+/**
+ * Implements the streaming version of the backup and restore functionality of
+ * Firebird Services API.
+ *
+ * @author <a href="mailto:rrokytskyy@users.sourceforge.net">Roman Rokytskyy</a>
+ * @author <a href="mailto:mrotteveel@users.sourceforge.net">Mark Rotteveel</a>
+ */
+public class FBStreamingBackupManager extends FBBackupManagerBase implements BackupManager {
+
+    private OutputStream backupOutputStream = null;
+    private BufferedInputStream restoreInputStream = null;
+
+    private int backupBufferSize = BUFFER_SIZE * 30; // 30K
+    private final int MAX_RESTORE_CHUNK = 65532;
+
+    private final int DATA_NOT_READY = 0;
+    private final int END_OF_STREAM = -1;
+
+    /**
+     * Set the local buffer size to be used when doing a backup. Default is
+     * 30720
+     *
+     * @param bufferSize
+     *        The buffer size to be used, a positive value
+     */
+    public void setBackupBufferSize(int bufferSize) {
+        if (bufferSize < 0) {
+            throw new IllegalArgumentException("Buffer size must be positive");
+        }
+        this.backupBufferSize = bufferSize;
+    }
+
+    /**
+     * Create a new instance of <code>FBStreamingBackupManager</code> based on
+     * the default GDSType.
+     */
+    public FBStreamingBackupManager() {
+    }
+
+    /**
+     * Create a new instance of <code>FBStreamingBackupManager</code> based on a
+     * given GDSType.
+     *
+     * @param gdsType
+     *        type must be PURE_JAVA, EMBEDDED, or NATIVE
+     */
+    public FBStreamingBackupManager(String gdsType) {
+        super(gdsType);
+    }
+
+    /**
+     * Create a new instance of <code>FBStreamingBackupManager</code> based on a
+     * given GDSType.
+     *
+     * @param gdsType
+     *        type must be PURE_JAVA, EMBEDDED, or NATIVE
+     */
+    public FBStreamingBackupManager(GDSType gdsType) {
+        super(gdsType);
+    }
+
+    public void setBackupPath(String backupPath) {
+        throw new IllegalArgumentException("You cannot use setBackupPath(String) for Streaming backups.");
+    }
+
+    public void addBackupPath(String path, int size) {
+        throw new IllegalArgumentException("You cannot use setBackupPath(String) for Streaming backups.");
+    }
+
+    public void setBackupOutputStream(OutputStream backupStream) {
+        backupOutputStream = backupStream;
+    }
+
+    public void setRestoreInputStream(InputStream restoreStream) {
+        restoreInputStream = (restoreStream instanceof BufferedInputStream)
+                ? (BufferedInputStream) restoreStream
+                : new BufferedInputStream(restoreStream, 128 * MAX_RESTORE_CHUNK);
+    }
+
+    public void clearBackupPaths() {
+        backupOutputStream = null;
+    }
+
+    public void backupDatabase(int options) throws SQLException {
+        if (backupOutputStream == null) {
+            throw new SQLException("No output stream specified for the backup.");
+        }
+
+        try (FbService service = attachServiceManager()) {
+            executeServiceBackupOperation(service, getBackupSRB(service, options));
+        }
+    }
+
+    public void restoreDatabase(int options) throws SQLException {
+        if (restoreInputStream == null) {
+            throw new SQLException("No input stream specified for the restore.");
+        }
+        try (FbService service = attachServiceManager()) {
+            executeServiceRestoreOperation(service, getRestoreSRB(service, options));
+        }
+    }
+
+    /**
+     * Streaming backups are currently not capable of verbose output
+     */
+    protected boolean verboseBackup() {
+        return false;
+    }
+
+    /**
+     * Set the page size that will be used for a restored database. The value
+     * for <code>pageSize</code> must be one of: 4096, 8192 or 16384. The
+     * default value depends on the Firebird version. Pages smaller than 4096
+     * were dropped in 2006 and are by definition unavailable with the streaming
+     * functionality of the Services API
+     *
+     * @param pageSize
+     *        The page size to be used in a restored database, one of 4196, 8192 or 16384
+     */
+    @Override
+    public void setRestorePageSize(int pageSize) {
+        if (pageSize < 4096) {
+            throw new IllegalArgumentException(
+                    "FirebirdSQL versions with streaming restore support don't support pages below 4096");
+        }
+        super.setRestorePageSize(pageSize);
+    }
+
+    /**
+     * Adds stdout as a source for the backup operation
+     *
+     * @param backupSPB
+     *        The buffer to be used during the backup operation
+     */
+    protected void addBackupsToBackupRequestBuffer(FbService service, ServiceRequestBuffer backupSPB) {
+        backupSPB.addArgument(isc_spb_bkp_file, "stdout", service.getEncoding());
+    }
+
+    /**
+     * Adds stdin as a source for the restore operation
+     *
+     * @param restoreSPB
+     *        The buffer to be used during the restore operation
+     */
+    protected void addBackupsToRestoreRequestBuffer(FbService service, ServiceRequestBuffer restoreSPB) {
+        restoreSPB.addArgument(isc_spb_bkp_file, "stdin", service.getEncoding());
+    }
+
+    private void executeServiceBackupOperation(FbService service, ServiceRequestBuffer srb) throws SQLException {
+        try {
+            service.startServiceAction(srb);
+
+            ServiceRequestBuffer infoSRB = service.createServiceRequestBuffer();
+            infoSRB.addArgument(isc_info_svc_to_eof);
+
+            int bufferSize = backupBufferSize;
+
+            boolean processing = true;
+
+            while (processing) {
+                byte[] buffer = service.getServiceInfo(null, infoSRB, bufferSize);
+
+                switch (buffer[0]) {
+                case isc_info_svc_to_eof:
+                    if (readOutput(buffer, 0, backupOutputStream) == END_OF_STREAM) {
+                        processing = false;
+                    }
+                    break;
+                case isc_info_truncated:
+                    bufferSize = bufferSize * 2;
+                    break;
+                case isc_info_end:
+                    processing = false;
+                    break;
+                }
+            }
+        } catch (IOException ioe) {
+            throw new SQLException(ioe);
+        }
+    }
+
+    private void executeServiceRestoreOperation(FbService service, ServiceRequestBuffer srb) throws SQLException {
+        try {
+            service.startServiceAction(srb);
+
+            OutputStream currentLogger = getLogger();
+            ServiceRequestBuffer infoSRB = service.createServiceRequestBuffer();
+            ServiceParameterBuffer infoSPB = null;
+            infoSRB.addArgument(isc_info_svc_stdin);
+            infoSRB.addArgument(isc_info_svc_line);
+
+            if (this.verbose && currentLogger == null)
+                throw new SQLException("Verbose mode was requested but there is no logger provided.");
+
+            int bufferSize = BUFFER_SIZE;
+            byte[] stdinBuffer = new byte[MAX_RESTORE_CHUNK];
+            byte[] newLine = System.getProperty("line.separator").getBytes();
+            boolean processing = true;
+            boolean sending = true;
+
+            byte[] buffer;
+
+            while (processing || infoSPB != null) {
+                buffer = service.getServiceInfo(infoSPB, infoSRB, bufferSize);
+
+                if (infoSPB != null && !sending) {
+                    infoSRB = service.createServiceRequestBuffer();
+                    infoSRB.addArgument(isc_info_svc_line);
+                }
+
+                infoSPB = null;
+
+                for (int codePos = 0; codePos < buffer.length && buffer[codePos] != isc_info_end;) {
+                    switch (buffer[codePos]) {
+                    case isc_info_svc_stdin:
+                        int requestedBytes = Math.min(iscVaxInteger(buffer, ++codePos, 4), stdinBuffer.length);
+                        codePos += 4;
+                        if (requestedBytes > 0) {
+                            int actuallyReadBytes = restoreInputStream.read(stdinBuffer, 0, requestedBytes);
+                            if (actuallyReadBytes > 0) {
+                                infoSPB = service.createServiceParameterBuffer();
+                                if (stdinBuffer.length == actuallyReadBytes)
+                                    infoSPB.addArgument(isc_info_svc_line, stdinBuffer);
+                                else
+                                    infoSPB.addArgument(isc_info_svc_line,
+                                            Arrays.copyOfRange(stdinBuffer, 0, actuallyReadBytes));
+                            }
+
+                            restoreInputStream.mark(2);
+                            if (restoreInputStream.read() < 0)
+                                sending = false;
+                            else
+                                restoreInputStream.reset();
+                        }
+                        break;
+                    case isc_info_truncated:
+                        bufferSize *= 2;
+                        ++codePos;
+                        break;
+                    case isc_info_svc_line:
+                        int bytesToLog = readOutput(buffer, codePos, currentLogger);
+                        codePos += 3;
+                        switch (bytesToLog) {
+                        case DATA_NOT_READY:
+                            ++codePos;
+                            break;
+                        case END_OF_STREAM:
+                            processing = false;
+                            break;
+                        default:
+                            codePos += bytesToLog;
+                            if (currentLogger != null)
+                                currentLogger.write(newLine);
+                        }
+                        break;
+                    case isc_info_end:
+                        break;
+                    default:
+                        throw new SQLException("Unexpected response from service. ");
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            throw new SQLException(ioe);
+        }
+    }
+
+    private int readOutput(byte[] buffer, int offset, OutputStream out) throws SQLException, IOException {
+        int dataLength = iscVaxInteger2(buffer, offset + 1);
+        if (dataLength == 0) {
+            switch (buffer[offset + 3]) {
+            case isc_info_data_not_ready:
+                return DATA_NOT_READY;
+            case isc_info_end:
+                return END_OF_STREAM;
+            default:
+                throw new SQLException("Unexpected end of stream reached.");
+            }
+        }
+        if (out != null) {
+            out.write(buffer, offset + 3, dataLength);
+        }
+        return dataLength;
+    }
+}


### PR DESCRIPTION
The code now looks presentable enough (I think)
Until @mrotteveel finds the time to look at it, I'll keep testing to make sure nothing broke during the final refactoring to extract a base class.
(Before that refactoring) I've tested backing up on just about every possible combination of :
Linux x64, LI-V2.5.4.26856
Windows x64, WI-V2.5.5.26952
Windows x86, WI-V2.5.5.26952
Linux armv7, LI-V2.5.2.26540
OpenJDK Runtime Environment (build 1.8.0_72-b15) (OpenSUSE, x86_64)
OpenJDK Runtime Environment (IcedTea 2.4.7) (7u55-2.4.7-1ubuntu1~0.13.10.1) (Linaro armv7)
Java(TM) SE Runtime Environment (build 1.7.0_55-b14) (WinXP, x86)
Java(TM) SE Runtime Environment (build 1.8.0_74-b02) (Win7, x86_64)

Both verbose and non-verbose restore have been tested (successfully), including a crossover of lin-created fbk to a win server and vice-versa after the last revelation. I've done most tests with a  small database (34242560 bytes fbk) but I did test a bigger database with combinations of the x86_64 hosts with no issues.

Btw, @mrotteveel , I did try increasing the restore chunk to 65535 but the engine reset my connection so I'm guessing it still treats size as signed.