### PR TITLE
Incorrect text used to search for session id.

### DIFF
--- a/src/main/org/firebirdsql/management/FBTraceManager.java
+++ b/src/main/org/firebirdsql/management/FBTraceManager.java
@@ -239,7 +239,7 @@ public class FBTraceManager extends FBServiceManager implements TraceManager {
 	}
 	
 	private class TraceStream extends FilterOutputStream {
-	    private static final String START_TEXT = "Trace session ID ";
+	    private static final String START_TEXT = "Session ID: ";
 	    
 	    private final String sessionName;
 	    private volatile boolean lookForSessionId = true;


### PR DESCRIPTION
Session ID: 10
  name:  powerpro
  user:  SYSDBA
  date:  2016-06-03 18:24:47
  flags: active, admin, trace

Session ID: 11
  name:  powerpro
  user:  SYSDBA
  date:  2016-06-03 22:59:09
  flags: active, admin, trace