### PR TITLE
Just making sure the we don't miss anything in case of unexpected response

### DIFF
--- a/src/main/org/firebirdsql/management/FBStreamingBackupManager.java
+++ b/src/main/org/firebirdsql/management/FBStreamingBackupManager.java
@@ -209,6 +209,8 @@ public class FBStreamingBackupManager extends FBBackupManagerBase implements Bac
                 case isc_info_end:
                     processing = false;
                     break;
+                default:
+                    throw new SQLException("Unexpected response from service.");
                 }
             }
         } catch (IOException ioe) {
@@ -293,7 +295,7 @@ public class FBStreamingBackupManager extends FBBackupManagerBase implements Bac
                     case isc_info_end:
                         break;
                     default:
-                        throw new SQLException("Unexpected response from service. ");
+                        throw new SQLException("Unexpected response from service.");
                     }
                 }
             }


### PR DESCRIPTION
After almost a solid month of backing up, I noticed two of the backups never finished creating and never threw an exception (that I can locate in any of the logs) for days. Output stream had also not been touched in that time.
Unfortunately, I could not determine the exact cause but I did look through the code and it seems somehow wrong to expect that case while restoring but not while backing up ;)
I'll be monitoring the situation a bit more closely but it may not repeat soon.