### PR TITLE
Do not call setCause if setLinkedException already called it.

### DIFF
--- a/src/main/org/firebirdsql/jca/FBResourceException.java
+++ b/src/main/org/firebirdsql/jca/FBResourceException.java
@@ -81,7 +81,7 @@ public class FBResourceException extends ResourceException {
         super(reason, SQLStateConstants.SQL_STATE_GENERAL_ERROR);
         // Preserve setLinkedException for backwards compatibility
         setLinkedException(original);
-        initCause(original);
+        if (getCause() != original) initCause(original);
         if (original instanceof SQLException) {
             SQLException origSql = (SQLException) original;
             if (origSql.getSQLState() != null) {


### PR DESCRIPTION
Hi,
For some uknown reason I'm getting IllegalStateException instead of verbose SQLException.
Maybe JVM in myproject is using another version of javax.resource.ResourceException instead of one bundled in jaybird-full-3.0.2.jar which calls initCause from setLinkedException. When initCause was called first, setLinkedException throwed IllegalStateException.

java.lang.IllegalStateException: Can't overwrite cause
        at java.lang.Throwable.initCause(Throwable.java:456)
        at org.firebirdsql.jca.FBResourceException.<init>(FBResourceException.java:90)

Please add suggested simple fix.