### PR TITLE
Use correct size for DEFAULT_MAX_INLINE_BLOB_SIZE

### DIFF
--- a/src/main/org/firebirdsql/jaybird/props/PropertyConstants.java
+++ b/src/main/org/firebirdsql/jaybird/props/PropertyConstants.java
@@ -58,7 +58,7 @@ public final class PropertyConstants {
 
     public static final boolean DEFAULT_ASYNC_FETCH = true;
 
-    public static final int DEFAULT_MAX_INLINE_BLOB_SIZE = 64 * 1024;
+    public static final int DEFAULT_MAX_INLINE_BLOB_SIZE = 65535;
     public static final int DEFAULT_MAX_BLOB_CACHE_SIZE = 10 * 1024 * 1024;
 
     // Default of true defined by JDBC (see Statement#setEscapeProcessing(boolean))


### PR DESCRIPTION
A fix for https://github.com/FirebirdSQL/jaybird/issues/937

Use the same size value as in the Firebird code: 
https://github.com/FirebirdSQL/firebird/blob/master/src/remote/remote.h#L107C43-L107C58
